### PR TITLE
Remove comment from `momentum` block helper

### DIFF
--- a/momentum.html
+++ b/momentum.html
@@ -1,6 +1,4 @@
 <template name="momentum">
-  <!-- XXX: Ask MDG to attach UI hooks to DomRange instead so we dont need 
-    this wrapper -->
   <div data-momentum>
     {{> UI.contentBlock}}
   </div>


### PR DESCRIPTION
The comment is included _everywhere_ where {{#momentum}} is called.
